### PR TITLE
Bound the ClickHouse insert buffer to fix unbounded heap growth (OOM)

### DIFF
--- a/src/main/kotlin/com/biron/singerTargetClickhouse/ClickhouseConnection.kt
+++ b/src/main/kotlin/com/biron/singerTargetClickhouse/ClickhouseConnection.kt
@@ -16,6 +16,8 @@ import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.*
 import java.util.concurrent.*
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 import kotlin.math.pow
 
 private val logger = KotlinLogging.logger {}
@@ -272,23 +274,53 @@ class ClickhouseConnection internal constructor(
 	 * and recycles them between batches — PipedInputStream would then raise
 	 * "Read end dead" on the next write after the original read thread died.
 	 */
-	internal class BlockingQueueInputStream : InputStream() {
-		private val queue = LinkedBlockingQueue<ByteArray>()
+	internal class BlockingQueueInputStream(
+		private val maxBufferedBytes: Int = DEFAULT_MAX_BUFFERED_BYTES,
+	) : InputStream() {
+		private val lock = ReentrantLock()
+		private val notFull = lock.newCondition()
+		private val notEmpty = lock.newCondition()
+		private val chunks = ArrayDeque<ByteArray>()
+		private var bufferedBytes: Int = 0
 		private var current: ByteArray = EMPTY
 		private var pos: Int = 0
-
-		@Volatile
 		private var completed: Boolean = false
 
+		/**
+		 * Enqueue [bytes], blocking up to [timeoutMs] while the buffer is full. Returns false only
+		 * when the timeout elapses with no room — the caller then decides whether to retry or bail
+		 * (e.g. because the server failed). An empty buffer always admits the next chunk, so a single
+		 * chunk larger than the cap cannot deadlock.
+		 */
+		fun offer(bytes: ByteArray, timeoutMs: Long): Boolean {
+			if (bytes.isEmpty()) return true
+			lock.withLock {
+				var remainingNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMs)
+				while (!completed && bufferedBytes > 0 && bufferedBytes + bytes.size > maxBufferedBytes) {
+					if (remainingNanos <= 0) return false
+					remainingNanos = notFull.awaitNanos(remainingNanos)
+				}
+				if (completed) return true // stream is closing; drop silently, matching put-after-complete
+				chunks.addLast(bytes)
+				bufferedBytes += bytes.size
+				notEmpty.signal()
+				return true
+			}
+		}
+
+		/** Unbounded-timeout [offer]: blocks until there is room (or the stream completes). */
 		fun put(bytes: ByteArray) {
-			if (completed || bytes.isEmpty()) return
-			queue.put(bytes)
+			offer(bytes, Long.MAX_VALUE)
 		}
 
 		fun complete() {
-			if (completed) return
-			completed = true
-			queue.put(EOF)
+			lock.withLock {
+				if (completed) return
+				completed = true
+				// Wake any blocked producer (it will see completed) and any waiting consumer.
+				notFull.signalAll()
+				notEmpty.signalAll()
+			}
 		}
 
 		override fun read(): Int {
@@ -307,8 +339,13 @@ class ClickhouseConnection internal constructor(
 
 		private fun ensureAvailable(): Boolean {
 			while (pos >= current.size) {
-				val next = queue.take()
-				if (next === EOF) return false
+				val next = lock.withLock {
+					while (chunks.isEmpty() && !completed) notEmpty.await()
+					chunks.pollFirst()?.also {
+						bufferedBytes -= it.size
+						notFull.signal() // releasing budget lets a blocked producer proceed
+					}
+				} ?: return false // completed and fully drained
 				current = next
 				pos = 0
 			}
@@ -317,7 +354,9 @@ class ClickhouseConnection internal constructor(
 
 		companion object {
 			private val EMPTY = ByteArray(0)
-			private val EOF = ByteArray(0)
+
+			/** Cap on bytes buffered in-flight to ClickHouse before [offer]/[put] blocks the producer. */
+			const val DEFAULT_MAX_BUFFERED_BYTES: Int = 64 * 1024 * 1024
 		}
 	}
 
@@ -331,6 +370,10 @@ class ClickhouseConnection internal constructor(
 
 		companion object {
 			private const val CLOSE_RESPONSE_TIMEOUT_SEC = 30L
+
+			// How long write() blocks on a full buffer before re-checking the server's response.
+			// Short enough that a failed insert surfaces promptly; long enough to avoid busy-spinning.
+			private const val BACKPRESSURE_POLL_MS = 50L
 
 			// No per-request timeout: one insert stream can stay open for the whole ingestion
 			// of a stream (millions of rows). Idle protection is handled on the caller side by
@@ -350,15 +393,23 @@ class ClickhouseConnection internal constructor(
 		override fun write(bytes: ByteArray) {
 			// If the server rejected the request mid-stream, surface the error now instead of
 			// silently dropping rows into a queue nobody is draining.
-			if (responseFuture.isDone) {
-				try {
-					val resp = responseFuture.get(0, TimeUnit.SECONDS)
-					error("ClickHouse insert completed prematurely (${resp.statusCode()}): ${resp.body()}")
-				} catch (e: ExecutionException) {
-					throw IllegalStateException("ClickHouse insert failed mid-stream", e.cause ?: e)
-				}
+			failIfServerFinished()
+			// The body queue is bounded, so offer() applies backpressure when ClickHouse reads slower
+			// than we produce. While blocked we keep re-checking the response: a stalled or failed
+			// server then surfaces as an error instead of hanging the producer forever.
+			while (!body.offer(bytes, BACKPRESSURE_POLL_MS)) {
+				failIfServerFinished()
 			}
-			body.put(bytes)
+		}
+
+		private fun failIfServerFinished() {
+			if (!responseFuture.isDone) return
+			try {
+				val resp = responseFuture.get(0, TimeUnit.SECONDS)
+				error("ClickHouse insert completed prematurely (${resp.statusCode()}): ${resp.body()}")
+			} catch (e: ExecutionException) {
+				throw IllegalStateException("ClickHouse insert failed mid-stream", e.cause ?: e)
+			}
 		}
 
 		override fun close() {

--- a/src/test/kotlin/com/biron/singerTargetClickhouse/ClickhouseConnectionTest.kt
+++ b/src/test/kotlin/com/biron/singerTargetClickhouse/ClickhouseConnectionTest.kt
@@ -21,7 +21,11 @@ import io.mockk.slot
 import org.springframework.jdbc.core.JdbcTemplate
 import java.net.http.HttpResponse
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
 
 class ClickhouseConnectionTest : ShouldSpec({
 
@@ -438,6 +442,27 @@ class ClickhouseConnectionTest : ShouldSpec({
 			}
 		}
 
+		should("write() surfaces a server failure that arrives while it is blocked on a full buffer") {
+			val body = BlockingQueueInputStream(maxBufferedBytes = 4)
+			val future = CompletableFuture<HttpResponse<String>>()
+			val underTest = HttpStreamingRowWriter(body, future)
+
+			underTest.write(ByteArray(4)) // fills the buffer (admitted into an empty buffer)
+
+			// Second write blocks on the full buffer; capture how it eventually returns.
+			val outcome = CompletableFuture<Throwable?>()
+			thread(start = true, isDaemon = true, name = "test-blocked-writer") {
+				outcome.complete(runCatching { underTest.write(ByteArray(4)) }.exceptionOrNull())
+			}
+			shouldThrow<TimeoutException> { outcome.get(300, TimeUnit.MILLISECONDS) } // must still be blocked
+
+			// Server then fails: the blocked write must wake and surface the error, not hang forever.
+			future.completeExceptionally(RuntimeException("connection reset"))
+			val thrown = outcome.get(5, TimeUnit.SECONDS)
+			thrown.shouldBeInstanceOf<IllegalStateException>()
+			thrown.message shouldContain "mid-stream"
+		}
+
 		should("write() forwards bytes to the body queue when the future is still in-flight") {
 			val body = BlockingQueueInputStream()
 			val future = CompletableFuture<HttpResponse<String>>() // never completes
@@ -542,6 +567,74 @@ class ClickhouseConnectionTest : ShouldSpec({
 			underTest.complete()
 			underTest.complete()
 			underTest.read() shouldBe -1
+		}
+
+		should("put() blocks the producer once maxBufferedBytes is full, then releases it when the consumer drains") {
+			val underTest = BlockingQueueInputStream(maxBufferedBytes = 16)
+			underTest.put(ByteArray(16)) // fills the buffer exactly (an empty buffer always admits one chunk)
+
+			val unblocked = CountDownLatch(1)
+			thread(start = true, isDaemon = true, name = "test-producer") {
+				underTest.put(ByteArray(16)) // must block: buffer is full
+				unblocked.countDown()
+			}
+
+			// While the buffer stays full the producer must not make progress (no backpressure today → fails).
+			unblocked.await(300, TimeUnit.MILLISECONDS) shouldBe false
+
+			// Draining the first chunk frees the budget and must release the blocked producer.
+			underTest.read(ByteArray(16), 0, 16) shouldBe 16
+			unblocked.await(5, TimeUnit.SECONDS) shouldBe true
+		}
+
+		should("offer() returns false when the buffer stays full for the whole timeout") {
+			val underTest = BlockingQueueInputStream(maxBufferedBytes = 4)
+			underTest.put(ByteArray(4)) // fills the buffer
+
+			underTest.offer(ByteArray(4), 50) shouldBe false
+		}
+
+		should("caps resident bytes at the buffer size, so a fast producer cannot exhaust the heap when the consumer stalls (the original OOM)") {
+			val cap = 256 * 1024 // 256 KiB ceiling
+			val chunkSize = 4 * 1024 // 4 KiB per write
+			val totalChunks = 100_000 // ~400 MiB total — would all be resident at once under the old unbounded queue
+			val maxResidentChunks = cap / chunkSize // 64
+
+			val underTest = BlockingQueueInputStream(maxBufferedBytes = cap)
+			val enqueued = AtomicInteger(0)
+			val producer = thread(start = true, isDaemon = true, name = "test-bulk-producer") {
+				repeat(totalChunks) {
+					underTest.put(ByteArray(chunkSize))
+					enqueued.incrementAndGet()
+				}
+				underTest.complete()
+			}
+
+			// Nothing is being read yet: the producer fills the cap and then must block. Wait for that.
+			val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+			while (producer.state !in setOf(Thread.State.WAITING, Thread.State.TIMED_WAITING) &&
+				System.nanoTime() < deadline
+			) {
+				Thread.onSpinWait()
+			}
+
+			// The OOM-prevention invariant: it could NOT enqueue all ~400 MiB. Peak resident bytes
+			// stay pinned at the cap regardless of how much the producer wants to push.
+			// (Under the old unbounded queue this would already be 100_000.)
+			(enqueued.get() <= maxResidentChunks + 1) shouldBe true
+
+			// Releasing the consumer lets the entire volume stream through, memory still bounded.
+			val readBuf = ByteArray(16 * 1024)
+			var totalRead = 0L
+			while (true) {
+				val n = underTest.read(readBuf, 0, readBuf.size)
+				if (n < 0) break
+				totalRead += n
+			}
+
+			totalRead shouldBe totalChunks.toLong() * chunkSize
+			producer.join(TimeUnit.SECONDS.toMillis(10))
+			enqueued.get() shouldBe totalChunks
 		}
 	}
 })


### PR DESCRIPTION
## Summary

The HTTP insert body was buffered in an **unbounded** queue and `write()` never blocked, so when ClickHouse drained the POST body slower than we produced it, every serialized row piled up on the heap. With a tap that emits `STATE` only at the end — the sole trigger that drains and closes the stream — this grew for the entire run and OOMed, even on a narrow (<50 column) schema with the default `batchSize`. This PR bounds the buffer by bytes so the producer gets backpressure, plus tests proving memory now stays capped.

## Root cause

`BlockingQueueInputStream` wrapped a `LinkedBlockingQueue<ByteArray>()` with no capacity, and `HttpStreamingRowWriter.write()` → `body.put(bytes)` never blocked. The queue only drained as fast as ClickHouse read the request body. Because the insert stream is drained/closed only on a `STATE` message (`commitPendingChanges` → `endIngestion` → `writer.close()`) or a 180s idle auto-end, a `STATE`-at-end tap meant the buffer grew across the whole run. The schema width and `batchSize` are irrelevant — heap scaled with **un-acked rows**.

This was confirmed by elimination: with no cleaning column, a flat schema, and `STATE` only at the end, the unbounded body queue was the only structure that grows O(rows) without release.

## The fix

- **`BlockingQueueInputStream` is now bounded by bytes** (`maxBufferedBytes`, default 64 MiB). `offer()` blocks while the buffer is full and returns `false` on timeout; an empty buffer always admits one chunk, so an oversized chunk can't deadlock. Switched the backing store to a lock + two conditions tracking `bufferedBytes`.
- **`write()` polls `offer()` and re-checks the response future** while blocked, so a stalled or failed server surfaces as an error instead of hanging the producer forever (the new risk introduced by making `put` blocking).

## Tests

- `put()` blocks once full, releases when the consumer drains.
- `offer()` returns `false` on timeout.
- `write()` surfaces a server failure that arrives **while blocked** on a full buffer (no hang).
- **High-volume memory bound:** a producer wanting to push ~400 MiB against a stalled consumer stays pinned at the cap (~64 chunks), then the full volume streams through intact once drained — the original OOM scenario.

All 50 `ClickhouseConnectionTest` cases pass; the regression tests were verified **RED** against the old unbounded behavior. The real-ClickHouse `StreamPipelineIntegrationTest` still passes, so inserts remain correct end-to-end.

## Notes / follow-ups

- The cap is a constructor default (64 MiB), not yet wired to `TargetConfig`. Happy to expose a `max_buffered_bytes` config key if wanted.
- The Docker entrypoint sets no `-Xmx`; adding `-XX:MaxRAMPercentage`/`-XX:+HeapDumpOnOutOfMemoryError` is a sensible belt-and-suspenders but no longer load-bearing for this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)